### PR TITLE
Fixed color output

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -439,9 +439,9 @@ end
 -- Conditionally enable color support.
 local color_maybe_supported = (stdout_isatty and os.getenv("TERM") and os.getenv("TERM") ~= "dumb")
 if color_maybe_supported and not os.getenv("DBG_NOCOLOR") then
-	COLOR_RED = "\x1b[31m"
-	COLOR_BLUE = "\x1b[34m"
-	COLOR_RESET = "\x1b[0m"
+	COLOR_RED = string.char(27) .. "[31m"
+	COLOR_BLUE = string.char(27) .. "[34m"
+	COLOR_RESET = string.char(27) .. "[0m"
 end
 
 -- Conditionally enable LuaJIT readline support.


### PR DESCRIPTION
Not sure why, but the escapes don't seem to work on Mac. Changed it to string.char instead.