### PR TITLE
Debugger UX Improvements

### DIFF
--- a/debugger.c.lua
+++ b/debugger.c.lua
@@ -1,4 +1,6 @@
-local lua_src = string.format("%q", io.open("debugger.lua"):read("a"))
+local lua_src_f = assert(io.open 'debugger.lua')
+local lua_src = string.format("%q", lua_src_f:read("a"))
+lua_src_f:close()
 
 -- Fix the weird escape characters
 lua_src = string.gsub(lua_src, "\\\n", "\\n")
@@ -114,4 +116,6 @@ int dbg_pcall(lua_State *lua, int nargs, int nresults, int _msgh){
 }
 ]]
 
-io.open("debugger.c", "w"):write(c_src)
+local c_src_f = assert(io.open('debugger.c', 'w'))
+c_src_f:write(c_src)
+c_src_f:close()

--- a/debugger.lua
+++ b/debugger.lua
@@ -348,7 +348,7 @@ local function match_command(line)
 		["s"] = function() return true, hook_step end,
 		["n"] = function() return true, hook_next end,
 		["f"] = function() return true, hook_finish end,
-		["p%s*(.*)"] = cmd_print,
+		["p%s+(.*)"] = cmd_print,
 		["u"] = cmd_up,
 		["d"] = cmd_down,
 		["t"] = cmd_trace,
@@ -356,7 +356,7 @@ local function match_command(line)
 		["h"] = function() dbg.writeln(help_message); return false end,
 		["S"] = function() dbg.enabled = false; return true end,
 		["q"] = function() os.exit() end,
-		["o%s*(%S*)%s*(%S*)"] = cmd_options
+		["o%s+(%S*)%s*(%S*)"] = cmd_options
 	}
 
 	for cmd, cmd_func in pairs(commands) do

--- a/debugger.lua
+++ b/debugger.lua
@@ -1,16 +1,16 @@
 --[[
 	Copyright (c) 2016 Scott Lembcke and Howling Moon Software
-	
+
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
 	in the Software without restriction, including without limitation the rights
 	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 	copies of the Software, and to permit persons to whom the Software is
 	furnished to do so, subject to the following conditions:
-	
+
 	The above copyright notice and this permission notice shall be included in
 	all copies or substantial portions of the Software.
-	
+
 	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,47 +18,58 @@
 	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 	SOFTWARE.
-	
+
 	TODO:
 	* Print short function arguments as part of stack location.
 	* Bug: sometimes doesn't advance to next line (same line event reported multiple times).
 	* Do coroutines work as expected?
 ]]
 
-
 -- Use ANSI color codes in the prompt by default.
 local COLOR_RED = ""
 local COLOR_BLUE = ""
 local COLOR_RESET = ""
 
-local function pretty(obj, recurse)
-	-- Returns true if a table has a __tostring metamethod.
-	local function coerceable(tbl)
-		local meta = getmetatable(tbl)
-		return (meta and meta.__tostring)
+local PRETTY_DEPTH = 1
+local NOEXPAND_KEYS = true
+local NOEXPAND_VALS = false
+local NOEXPAND_LOCAL = true
+
+local function pretty(obj, lvl, noexpand, copy)
+	lvl = lvl or 0
+	local nlvl = lvl + 1
+	local _t = "\n"..string.rep("\t", lvl)
+	local _tt = _t .. "\t"
+	copy = copy or {}
+	local __tostring = tostring
+	-- tostring() can fail if there is an error in a __tostring metamethod.
+	local function tostring(obj)
+		local success, value = pcall(function() return __tostring(obj) end)
+		return (success and value or "<!!error in __tostring metamethod!!>")
 	end
-	
+
 	if type(obj) == "string" then
 		-- Dump the string so that escape sequences are printed.
 		return string.format("%q", obj)
-	elseif type(obj) == "table" and not coerceable(obj) and not recurse then
-		local str = "{"
-		
+	elseif type(obj) == "table" and lvl < PRETTY_DEPTH and not noexpand then
+		if copy[obj] then return tostring(obj)..COLOR_BLUE.." (R)"..COLOR_RESET end
+		copy[obj] = true
+		local str = tostring(obj).._t.."{"
+
 		for k, v in pairs(obj) do
-			local pair = pretty(k, true).." = "..pretty(v, true)
-			str = str..(str == "{" and pair or ", "..pair)
+			local pair = _tt..pretty(k, nlvl, NOEXPAND_KEYS, copy).." = "..pretty(v, nlvl, false, copy)
+			str = str..(str:sub(#str) == "{" and pair or ", "..pair)
 		end
-		
-		return str.."}"
+
+		return str.._t.."}"
 	else
-		-- tostring() can fail if there is an error in a __tostring metamethod.
-		local success, value = pcall(function() return tostring(obj) end)
-		return (success and value or "<!!error in __tostring metamethod!!>")
+		return tostring(obj)
 	end
 end
 
 local help_message = [[
 [return] - re-run last command
+[statement] - execute statement and print the results
 c(ontinue) - contiue execution
 s(tep) - step forward by one line (into functions)
 n(ext) - step forward by one line (skipping over functions)
@@ -67,8 +78,16 @@ f(inish) - step forward until exiting the current function
 u(p) - move up the stack by one frame
 d(own) - move down the stack by one frame
 t(race) - print the stack trace
-l(ocals) - print the function arguments, locals and upvalues.
+l(ocals)[e] - print the function arguments, locals and upvalues, optionally expanding tables
 h(elp) - print this message
+o(ption) <name> [val] - Set an option
+	- dbg_enabled <on|off> - Enable the debugger
+	- depth <num> - Default table expansion depth
+	- xkeys <on|off> - Control expansion of table keys
+	- xvals <on|off> - Control expansion of table values
+	- xloc <on|off> - Perform table expansion in 'locals' view.
+S(top) - stop debugging
+q(uit) - exit the program
 ]]
 
 -- The stack level that cmd_* functions use to access locals or info
@@ -116,17 +135,16 @@ local function hook_factory(repl_threshold)
 	return function(offset)
 		return function(event, _)
 			local info = debug.getinfo(2)
-			
 			if event == "call" and info.linedefined >= 0 then
 				offset = offset + 1
 			elseif event == "return" and info.linedefined >= 0 then
-				if offset <= repl_threshold then
+				--[[if offset <= repl_threshold then
 					-- TODO this is what causes the duplicated lines
 					-- Don't remember why this is even here...
 					--repl()
 				else
-					offset = offset - 1
-				end
+				end]]
+				offset = offset - 1
 			elseif event == "line" and offset <= repl_threshold then
 				repl()
 			end
@@ -142,7 +160,7 @@ local function table_merge(t1, t2)
 	local tbl = {}
 	for k, v in pairs(t1) do tbl[k] = v end
 	for k, v in pairs(t2) do tbl[k] = v end
-	
+
 	return tbl
 end
 
@@ -152,21 +170,21 @@ local function local_bindings(offset, include_globals)
 	local level = stack_offset + offset + LOCAL_STACK_LEVEL
 	local func = debug.getinfo(level).func
 	local bindings = {}
-	
+
 	-- Retrieve the upvalues
 	do local i = 1; repeat
 		local name, value = debug.getupvalue(func, i)
 		if name then bindings[name] = value end
 		i = i + 1
 	until name == nil end
-	
+
 	-- Retrieve the locals (overwriting any upvalues)
 	do local i = 1; repeat
 		local name, value = debug.getlocal(level, i)
 		if name then bindings[name] = value end
 		i = i + 1
 	until name == nil end
-	
+
 	-- Retrieve the varargs. (works in Lua 5.2 and LuaJIT)
 	local varargs = {}
 	do local i = -1; repeat
@@ -175,12 +193,12 @@ local function local_bindings(offset, include_globals)
 		i = i - 1
 	until name == nil end
 	if #varargs ~= 0 then bindings["..."] = varargs end
-	
+
 	if include_globals then
 		-- Merge the local bindings over the top of the environment table.
 		-- In Lua 5.2, you have to get the environment table from the function's locals.
 		local env = (_VERSION <= "Lua 5.1" and getfenv(func) or bindings._ENV)
-		
+
 		-- Finally, merge the tables and add a lookup for globals.
 		return setmetatable(table_merge(env or {}, bindings), {__index = _G})
 	else
@@ -191,14 +209,14 @@ end
 -- Compile an expression with the given variable bindings.
 local function compile_chunk(expr, env)
 	local source = "debugger.lua REPL"
-	
+
 	if _VERSION <= "Lua 5.1" then
-		local chunk = loadstring("return "..expr, source)
+		local chunk = loadstring("return "..expr, source) or loadstring(expr, source)
 		if chunk then setfenv(chunk, env) end
 		return chunk
 	else
 		-- The Lua 5.2 way is a bit cleaner
-		return load("return "..expr, source, "t", env)
+		return load("return "..expr, source, "t", env) or load(expr, source, "t", env)
 	end
 end
 
@@ -212,10 +230,10 @@ local function cmd_print(expr)
 		dbg.writeln(COLOR_RED.."Error: Could not evaluate expression."..COLOR_RESET)
 		return false
 	end
-	
+
 	-- Call the chunk and collect the results.
 	local results = {pcall(chunk, unpack(rawget(env, "...") or {}))}
-	
+
 	-- The first result is the pcall error.
 	if not results[1] then
 		dbg.writeln(COLOR_RED.."Error:"..COLOR_RESET.." %s", results[2])
@@ -226,22 +244,22 @@ local function cmd_print(expr)
 		for i = 2, #results do
 			result = result..(i ~= 2 and ", " or "")..pretty(results[i])
 		end
-		
+
 		dbg.writeln(COLOR_BLUE..expr..COLOR_RED.." => "..COLOR_RESET..result)
 	end
-	
+
 	return false
 end
 
 local function cmd_up()
 	local info = debug.getinfo(stack_offset + LOCAL_STACK_LEVEL + 1)
-	
+
 	if info then
 		stack_offset = stack_offset + 1
 	else
 		dbg.writeln(COLOR_BLUE.."Already at the top of the stack."..COLOR_RESET)
 	end
-	
+
 	dbg.writeln("Inspecting frame: "..format_stack_frame_info(debug.getinfo(stack_offset + LOCAL_STACK_LEVEL)))
 	return false
 end
@@ -252,7 +270,7 @@ local function cmd_down()
 	else
 		dbg.writeln(COLOR_BLUE.."Already at the bottom of the stack."..COLOR_RESET)
 	end
-	
+
 	dbg.writeln("Inspecting frame: "..format_stack_frame_info(debug.getinfo(stack_offset + LOCAL_STACK_LEVEL)))
 	return false
 end
@@ -262,39 +280,64 @@ local function cmd_trace()
 	local offset = stack_offset - stack_top
 	local message = string.format("Inspecting frame: %d - (%s)", offset, location)
 	local str = debug.traceback(message, stack_top + LOCAL_STACK_LEVEL)
-	
+
 	-- Iterate the lines of the stack trace so we can highlight the current one.
 	local line_num = -2
 	while str and #str ~= 0 do
 		local line, rest = string.match(str, "([^\n]*)\n?(.*)")
 		str = rest
-		
+
 		if line_num >= 0 then line = tostring(line_num)..line end
 		dbg.writeln((line_num + stack_top == stack_offset) and COLOR_BLUE..line..COLOR_RESET or line)
 		line_num = line_num + 1
 	end
-	
+
 	return false
 end
 
-local function cmd_locals()
+local function cmd_locals(extended)
 	local bindings = local_bindings(1, false)
-	
+	local noex = #extended == 0 and NOEXPAND_LOCAL
+
 	-- Get all the variable binding names and sort them
 	local keys = {}
 	for k, _ in pairs(bindings) do table.insert(keys, k) end
 	table.sort(keys)
-	
+
 	for _, k in ipairs(keys) do
 		local v = bindings[k]
-		
+
 		-- Skip the debugger object itself, temporaries and Lua 5.2's _ENV object.
 		if not rawequal(v, dbg) and k ~= "_ENV" and k ~= "(*temporary)" then
-			dbg.writeln("\t"..COLOR_BLUE.."%s "..COLOR_RED.."=>"..COLOR_RESET.." %s", k, pretty(v))
+			dbg.writeln("\t"..COLOR_BLUE.."%s "..COLOR_RED.."=>"..COLOR_RESET.." %s", k, pretty(v, 1, noex))
 		end
 	end
-	
+
 	return false
+end
+
+local function cmd_options(name, val)
+	val = val or ""
+	local function yesno(v)
+		if v:match 'off' or v:match 'no' or v:match 'false' then
+			return false
+		else return true end
+	end
+	local function tonum(v) return tonumber(val:match"%d+") end
+	if name == "dbg_enabled" then
+		dbg.enabled = yesno(val)
+	elseif name == "depth" then
+		PRETTY_DEPTH = tonum(val) or PRETTY_DEPTH
+	elseif name == "xkeys" then
+		NOEXPAND_KEYS = not yesno(val)
+	elseif name == "xvals" then
+		NOEXPAND_VALS = not yesno(val)
+	elseif name == "xloc" then
+		NOEXPAND_LOCAL = not yesno(val)
+	else
+		dbg.writeln(COLOR_RED.."Please specify a valid option name."..COLOR_RESET)
+		return
+	end
 end
 
 local last_cmd = false
@@ -305,20 +348,24 @@ local function match_command(line)
 		["s"] = function() return true, hook_step end,
 		["n"] = function() return true, hook_next end,
 		["f"] = function() return true, hook_finish end,
-		["p%s?(.*)"] = cmd_print,
+		["p%s*(.*)"] = cmd_print,
 		["u"] = cmd_up,
 		["d"] = cmd_down,
 		["t"] = cmd_trace,
-		["l"] = cmd_locals,
+		["l%s*(e?)"] = cmd_locals,
 		["h"] = function() dbg.writeln(help_message); return false end,
+		["S"] = function() dbg.enabled = false; return true end,
+		["q"] = function() os.exit() end,
+		["o%s*(%S*)%s*(%S*)"] = cmd_options
 	}
-	
+
 	for cmd, cmd_func in pairs(commands) do
 		local matches = {string.match(line, "^("..cmd..")$")}
 		if matches[1] then
-			return cmd_func, select(2, unpack(matches))
+			return cmd_func, {select(2, unpack(matches))}
 		end
 	end
+	return cmd_print, {line}
 end
 
 -- Run a command line
@@ -329,18 +376,18 @@ local function run_command(line)
 		dbg.writeln()
 		return true
 	end
-	
+
 	-- Re-execute the last command if you press return.
 	if line == "" then
 		if last_cmd then line = last_cmd else return false end
 	else
 		last_cmd = line
 	end
-	
+
 	local command, command_arg = match_command(line)
 	if command then
 		-- unpack({...}) prevents tail call elimination so the stack frame indices are predictable.
-		return unpack({command(command_arg)})
+		return unpack({command(unpack(command_arg))})
 	else
 		dbg.writeln(COLOR_RED.."Error:"..COLOR_RESET.." command '%s' not recognized.\nType 'h' and press return for a command list.", line)
 		return false
@@ -349,7 +396,7 @@ end
 
 repl = function()
 	dbg.writeln(format_stack_frame_info(debug.getinfo(LOCAL_STACK_LEVEL - 3 + stack_top)))
-	
+
 	repeat
 		local success, done, hook = pcall(run_command, dbg.read(COLOR_RED.."debugger.lua> "..COLOR_RESET))
 		if success then
@@ -365,16 +412,18 @@ end
 -- Make the debugger object callable like a function.
 dbg = setmetatable({}, {
 	__call = function(self, condition, offset)
-		if condition then return end
-		
+		if condition or not self.enabled then return end
+
 		offset = (offset or 0)
 		stack_offset = offset
 		stack_top = offset
-		
+
 		debug.sethook(hook_next(1), "crl")
 		return
 	end,
 })
+
+dbg.enabled = true
 
 -- Expose the debugger's IO functions.
 dbg.read = dbg_read
@@ -382,12 +431,15 @@ dbg.write = dbg_write
 dbg.writeln = dbg_writeln
 dbg.pretty = pretty
 
+function dbg.off() dbg.enabled = false end
+function dbg.on() dbg.enabled = true end
+
 -- Works like error(), but invokes the debugger.
 function dbg.error(err, level)
 	level = level or 1
 	dbg.writeln(COLOR_RED.."Debugger stopped on error:"..COLOR_RESET.."(%s)", pretty(err))
 	dbg(false, level)
-	
+
 	error(err, level)
 end
 
@@ -397,7 +449,7 @@ function dbg.assert(condition, message)
 		dbg.writeln(COLOR_RED.."Debugger stopped on "..COLOR_RESET.."assert(..., %s)", message)
 		dbg(false, 1)
 	end
-	
+
 	assert(condition, message)
 end
 
@@ -406,7 +458,7 @@ function dbg.call(f, l)
 	return (xpcall(f, function(err)
 		dbg.writeln(COLOR_RED.."Debugger stopped on error: "..COLOR_RESET..pretty(err))
 		dbg(false, (l or 0) + 1)
-		
+
 		-- Prevent a tail call to dbg().
 		return
 	end))
@@ -416,8 +468,14 @@ end
 function dbg.msgh(...)
 	dbg.write(...)
 	dbg(false, 1)
-	
+
 	return ...
+end
+
+-- install the debugger globally
+function dbg.install()
+	_G.dbg = dbg
+	return dbg
 end
 
 -- Detect Lua version.
@@ -440,11 +498,11 @@ if ffi then
 	ffi.cdef[[
 		bool isatty(int);
 		void free(void *ptr);
-		
+
 		char *readline(const char *);
 		int add_history(const char *);
 	]]
-	
+
 	stdin_isatty = ffi.C.isatty(0)
 	stdout_isatty = ffi.C.isatty(1)
 end
@@ -462,7 +520,7 @@ local dbg_readline = nil
 pcall(function()
 	if ffi and stdin_isatty and not os.getenv("DBG_NOREADLINE") then
 		local readline = ffi.load("readline")
-		
+
 		dbg_readline = function(prompt)
 			local cstr = readline.readline(prompt)
 			if cstr ~= nil then
@@ -470,17 +528,34 @@ pcall(function()
 				if string.match(str, "[^%s]+") then
 					readline.add_history(cstr)
 				end
-				
+
 				ffi.C.free(cstr)
 				return str
 			else
 				return nil
 			end
 		end
-		
+
 		dbg.read = dbg_readline
 		dbg.writeln(COLOR_RED.."debugger.lua: Readline support enabled."..COLOR_RESET)
 	end
+end)
+
+local dbg_linenoise = nil
+pcall(function ()
+	local linenoise = require 'linenoise'
+	dbg_linenoise = function(prompt)
+		-- Linenoise doesn't play nice with non-printing characters in the prompt.
+		prompt = prompt:gsub("\027%[[%d;]+m", "")
+		local str = linenoise.read(prompt)
+		if str and str:match "%S" then
+			linenoise.historyAdd(str)
+		end
+		return str
+	end
+
+	dbg.read = dbg_linenoise
+	dbg.writeln(COLOR_RED.."debugger.lua: Linenoise support enabled."..COLOR_RESET)
 end)
 
 return dbg

--- a/debugger.lua
+++ b/debugger.lua
@@ -317,7 +317,7 @@ local function cmd_locals(extended)
 end
 
 local function cmd_options(name, val)
-	val = val or ""
+	val = val and tostring(val) or ""
 	local function yesno(v)
 		if v:match 'off' or v:match 'no' or v:match 'false' then
 			return false
@@ -431,6 +431,7 @@ dbg.write = dbg_write
 dbg.writeln = dbg_writeln
 dbg.pretty = pretty
 
+function dbg.opt(name, val) cmd_options(name, val) return dbg end
 function dbg.off() dbg.enabled = false end
 function dbg.on() dbg.enabled = true end
 


### PR DESCRIPTION
Quick highlight of the proposed changes:
- New `q[uit]` command to stop executing the program immediately.
- New `S[top]` command to disable all breakpoints.
- New pretty printing functionality redesigned for inspecting long/complex tables and subtables; handles recursion and custom `__tostring` metamethods gracefully.
- New `o[ption] <name> <val>` command to set debugger options.  Primarily used to control the new pretty printing.
- `l[ocals]` view no longer expands tables, for readability reasons.  Using the 'le' form re-enables this. (Note: the printing depth will have to be set to 2 or greater (via `o depth 2` for this.)
- New `dbg.on`/`dbg.off` functions, used to enable/disable breakpoints.
- New `dbg.opt` function, used as an alternative to 'o <name> <val>' every time the debugger is loaded.
- New `dbg.install` function, places the debugger object in the global namespace as `dbg`.
- Chunk compilation has been patched to allow expressions that cannot be prefixed with a return statement.
- Any non-command statement is now treated as an implicit `p[rint] <exp>` statement.  This results in a much improved debugging workflow.

It also now supports using Antirez's [Linenoise](https://github.com/antirez/linenoise), via my [bindings](https://github.com/web-eworks/linenoise-lua).

Any comments?
