### PR TITLE
Add q(uit)/w(here) Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If you have used other CLI debuggers, debugger.lua should present no surprises. 
 	f(inish) - step forward until exiting the current function
 	u(p) - move up the stack by one frame
 	d(own) - move down the stack by one frame
+	w(here) - print source code around current line
 	t(race) - print the stack trace
 	l(ocals) - print the function arguments, locals and upvalues.
 	h(elp) - print this message

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you have used other CLI debuggers, debugger.lua should present no surprises. 
 	f(inish) - step forward until exiting the current function
 	u(p) - move up the stack by one frame
 	d(own) - move down the stack by one frame
-	w(here) - print source code around current line
+	w(here) [line count] - print source code around the current line
 	t(race) - print the stack trace
 	l(ocals) - print the function arguments, locals and upvalues.
 	h(elp) - print this message

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If you have used other CLI debuggers, debugger.lua should present no surprises. 
 	t(race) - print the stack trace
 	l(ocals) - print the function arguments, locals and upvalues.
 	h(elp) - print this message
+	q(uit) - halt execution
 
 If you've never used a CLI debugger before. Start a nice warm cozy fire, run tutorial.lua and open it up in your favorite editor so you can follow along.
 

--- a/debugger.lua
+++ b/debugger.lua
@@ -69,7 +69,7 @@ d(own) - move down the stack by one frame
 t(race) - print the stack trace
 l(ocals) - print the function arguments, locals and upvalues.
 h(elp) - print this message
-]]
+q(uit) - halt execution]]
 
 -- The stack level that cmd_* functions use to access locals or info
 -- The structure of the code very carefully ensures this.
@@ -311,6 +311,7 @@ local function match_command(line)
 		["t"] = cmd_trace,
 		["l"] = cmd_locals,
 		["h"] = function() dbg.writeln(help_message); return false end,
+		["q"] = function() os.exit(0) end,
 	}
 	
 	for cmd, cmd_func in pairs(commands) do

--- a/debugger.lua
+++ b/debugger.lua
@@ -147,15 +147,24 @@ local function table_merge(t1, t2)
 	return tbl
 end
 
-local function split_string(s, sep)
+local function split_string(str, sep)
   local sep = sep or "\n"
-  -- TODO(JRC): Improve this so that two consective separators produce an
-  -- empty string component.
-  local pattern = string.format("([^%s]+)", sep)
+  local pattern = string.format("(.-)(%s)", sep)
 
-  local comps = {}
-  string.gsub(s, pattern, function(c) table.insert(comps, c) end)
-  return comps
+  local components = {}
+
+  local spos, epos, capture = string.find(str, pattern, 1)
+  local last_epos = 1
+  while spos do
+    table.insert(components, capture)
+    last_epos = epos + 1
+    spos, epos, capture = string.find(str, pattern, last_epos)
+  end
+  if last_epos <= #str then
+    table.insert(components, string.sub(str, last_epos))
+  end
+
+  return components
 end
 
 -- Create a table of all the locally accessible variables.
@@ -287,7 +296,7 @@ local function cmd_where(line_num)
   else
     -- TODO(JRC): Modify this code so that the index values for newlines are
     -- used instead of generated tables to improve memory use.
-    local source_lines = split_string(source, "\n")
+    local source_lines = split_string(source, '\n')
 
     local line_num = tonumber(line_num) or 5
     local source_start = math.max(1, source_current - line_num)


### PR DESCRIPTION
The changes in this pull request add the following commands to `debugger.lua`:

- `q(uit)`: Terminates the program running the debugger.
- `w(here)`: Prints out the lines surrounding the current execution line (similar to `where` in the Python debugger).

These commands aren't currently included in the tutorial file, but they could be added relatively easily if needed.  Also, it's important to note that this PR conflicts with PR #7 since both implement the `q(uit)` command, but I'd be happy to rebase if that PR is merged first.

Please let me know if there are any problems with this PR and I'll try to revise it as soon as I can!