### PR TITLE
improve dbg.call parity with pcall

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -420,14 +420,21 @@ function dbg.assert(condition, message)
 end
 
 -- Works like pcall(), but invokes the debugger on an error.
-function dbg.call(f, l)
-	return xpcall(f, function(err)
+function dbg.call(f, ...)
+	local catch = function(err)
 		dbg.writeln(COLOR_RED.."Debugger stopped on error: "..COLOR_RESET..pretty(err))
-		dbg(false, (l or 0) + 1)
-		
+		dbg(false, 2)
+
 		-- Prevent a tail call to dbg().
 		return
-	end)
+	end
+	if select('#', ...) > 0 then
+		local args = {...}
+		return xpcall(function()
+			return f(unpack(args))
+		end, catch)
+	end
+	return xpcall(f, catch)
 end
 
 -- Error message handler that can be used with lua_pcall().

--- a/debugger.lua
+++ b/debugger.lua
@@ -425,8 +425,7 @@ function dbg.call(f, ...)
 		dbg.writeln(COLOR_RED.."Debugger stopped on error: "..COLOR_RESET..pretty(err))
 		dbg(false, 2)
 
-		-- Prevent a tail call to dbg().
-		return
+		return err
 	end
 	if select('#', ...) > 0 then
 		local args = {...}

--- a/debugger.lua
+++ b/debugger.lua
@@ -421,13 +421,13 @@ end
 
 -- Works like pcall(), but invokes the debugger on an error.
 function dbg.call(f, l)
-	return (xpcall(f, function(err)
+	return xpcall(f, function(err)
 		dbg.writeln(COLOR_RED.."Debugger stopped on error: "..COLOR_RESET..pretty(err))
 		dbg(false, (l or 0) + 1)
 		
 		-- Prevent a tail call to dbg().
 		return
-	end))
+	end)
 end
 
 -- Error message handler that can be used with lua_pcall().


### PR DESCRIPTION
Before this commit, `dbg.call` only returns `true` or ` false`.

For feature parity with `pcall`, it must pass the entire tuple back to its caller.

```lua
local ok, a, b, c = dbg.call(function()
  return 1, 2, 3
end)
```