### PR TITLE
enable ansi prompt for linenoise

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -499,8 +499,6 @@ if stdin_isatty and not os.getenv("DBG_NOREADLINE") then
 		end)
 
 		dbg.read = function(prompt)
-			-- Linenoise doesn't play nice with non-printing characters in the prompt.
-			prompt = prompt:gsub("\027%[[%d;]+m", "")
 			local str = linenoise.linenoise(prompt)
 			if str and not str:match "^%s*$" then
 				linenoise.historyadd(str)


### PR DESCRIPTION
https://github.com/hoelzro/lua-linenoise now supports colored prompts thanks to [this commit](https://github.com/hoelzro/lua-linenoise/commit/aa5d70355171e32361771c336adee9ca3e794fcc), so we can remove the code that strips out ANSI characters.