### PR TITLE
feat: add where command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If you have used other CLI debuggers, debugger.lua should present no surprises. 
 	f(inish) - step forward until exiting the current function
 	u(p) - move up the stack by one frame
 	d(own) - move down the stack by one frame
+	w(here) [line count] - print source code around the current line
 	t(race) - print the stack trace
 	l(ocals) - print the function arguments, locals and upvalues.
 	h(elp) - print this message

--- a/debugger.lua
+++ b/debugger.lua
@@ -297,37 +297,38 @@ local function cmd_down()
 end
 
 local function cmd_where(line_num)
-  local info = debug.getinfo(stack_offset + LOCAL_STACK_LEVEL)
+	local info = debug.getinfo(stack_offset + LOCAL_STACK_LEVEL)
+	if not info then return end
 
-  local source = info.source
-  local source_lidx = info.currentline
+	local source = info.source
+	local source_lidx = info.currentline
 
-  local source_filename = string.match(source, "^@(.*)$")
-  if source_filename then
-    if source_contents[source_filename] then
-      source = source_contents[source_filename]
-    else
-      local source_file = io.open(source_filename, "r")
-      if not source_file then source = nil
-      else source = source_file:read("*a"); source_file:close() end
+	local source_filename = string.match(source, "^@(.*)$")
+	if source_filename then
+		if source_contents[source_filename] then
+			source = source_contents[source_filename]
+		else
+			local source_file = io.open(source_filename, "r")
+			if not source_file then source = nil
+			else source = source_file:read("*a"); source_file:close() end
 
-      source_contents[source_filename] = source
-    end
-  end
+			source_contents[source_filename] = source
+		end
+	end
 
-  if not source then
-    dbg.writeln(COLOR_RED.."Error: Could not find source file for current function."..COLOR_RESET)
-  else
-    local line_num = tonumber(line_num) or 5
-    local line_min, line_max = source_lidx - line_num, source_lidx + line_num
+	if not source then
+		dbg.writeln(COLOR_RED.."Error: Could not find source file for current function."..COLOR_RESET)
+	else
+		local line_num = tonumber(line_num) or 5
+		local line_min, line_max = source_lidx - line_num, source_lidx + line_num
 
-    for lidx, source_line in istring(source, "\n") do
-      if lidx >= line_min and lidx <= line_max then
-        dbg.writeln(COLOR_BLUE.."%d\t"..COLOR_RED.."%s"..COLOR_RESET.."%s",
-          tonumber(lidx), (lidx == source_lidx and "=> " or "   "), source_line)
-      end
-    end
-  end
+		for lidx, source_line in istring(source, "\n") do
+			if lidx >= line_min and lidx <= line_max then
+				dbg.writeln(COLOR_BLUE.."%d\t"..COLOR_RED.."%s"..COLOR_RESET.."%s",
+				tonumber(lidx), (lidx == source_lidx and "=> " or "   "), source_line)
+			end
+		end
+	end
 end
 
 local function cmd_trace()

--- a/debugger.lua
+++ b/debugger.lua
@@ -66,6 +66,7 @@ p(rint) [expression] - execute the expression and print the result
 f(inish) - step forward until exiting the current function
 u(p) - move up the stack by one frame
 d(own) - move down the stack by one frame
+w(here) [line count] - print source code around the current line
 t(race) - print the stack trace
 l(ocals) - print the function arguments, locals and upvalues.
 h(elp) - print this message
@@ -82,6 +83,8 @@ local stack_top = 0
 -- The current stack frame index.
 -- Changed using the up/down commands
 local stack_offset = 0
+
+local source_contents = {}
 
 local dbg
 
@@ -144,6 +147,26 @@ local function table_merge(t1, t2)
 	for k, v in pairs(t2) do tbl[k] = v end
 	
 	return tbl
+end
+
+local function istring(str, sep)
+  local sep = sep or "\n"
+  local pattern = string.format("(.-)(%s)", sep)
+
+  local ipos, iidx = 1, 0
+  return function()
+    iidx = iidx + 1
+
+    local spos, epos, capture = string.find(str, pattern, ipos)
+    if spos then
+      ipos = epos + 1
+      return iidx, capture
+    elseif ipos <= #str then
+      capture = string.sub(str, ipos)
+      ipos = #str + 1
+      return iidx, capture
+    end
+  end
 end
 
 -- Create a table of all the locally accessible variables.
@@ -273,6 +296,40 @@ local function cmd_down()
 	return false
 end
 
+local function cmd_where(line_num)
+  local info = debug.getinfo(stack_offset + LOCAL_STACK_LEVEL)
+
+  local source = info.source
+  local source_lidx = info.currentline
+
+  local source_filename = string.match(source, "^@(.*)$")
+  if source_filename then
+    if source_contents[source_filename] then
+      source = source_contents[source_filename]
+    else
+      local source_file = io.open(source_filename, "r")
+      if not source_file then source = nil
+      else source = source_file:read("*a"); source_file:close() end
+
+      source_contents[source_filename] = source
+    end
+  end
+
+  if not source then
+    dbg.writeln(COLOR_RED.."Error: Could not find source file for current function."..COLOR_RESET)
+  else
+    local line_num = tonumber(line_num) or 5
+    local line_min, line_max = source_lidx - line_num, source_lidx + line_num
+
+    for lidx, source_line in istring(source, "\n") do
+      if lidx >= line_min and lidx <= line_max then
+        dbg.writeln(COLOR_BLUE.."%d\t"..COLOR_RED.."%s"..COLOR_RESET.."%s",
+          tonumber(lidx), (lidx == source_lidx and "=> " or "   "), source_line)
+      end
+    end
+  end
+end
+
 local function cmd_trace()
 	local location = format_stack_frame_info(debug.getinfo(stack_offset + LOCAL_STACK_LEVEL))
 	local offset = stack_offset - stack_top
@@ -325,6 +382,7 @@ local function match_command(line)
 		["e%s?(.*)"] = cmd_eval,
 		["u"] = cmd_up,
 		["d"] = cmd_down,
+		["w%s?(%d*)"] = cmd_where,
 		["t"] = cmd_trace,
 		["l"] = cmd_locals,
 		["h"] = function() dbg.writeln(help_message); return false end,


### PR DESCRIPTION
I squashed the commits by @churay that add a where command that print the lines of code surrounding the current breakpoint.

```lua
debugger.lua> w
58	             stream.headers = headers
59	           else
60	             return stream:shutdown(), app:onerror(err)
61	           end
62	           dbg()
63	=>         local res = setmetatable({
64	             headers = http_headers.new()
65	           }, res_mt)
66	           local _list_0 = app.pipes
67	           for _index_0 = 1, #_list_0 do
68	             local _continue_0 = false
debugger.lua> w 7
56	           local headers, err = stream:get_headers()
57	           if headers then
58	             stream.headers = headers
59	           else
60	             return stream:shutdown(), app:onerror(err)
61	           end
62	           dbg()
63	=>         local res = setmetatable({
64	             headers = http_headers.new()
65	           }, res_mt)
66	           local _list_0 = app.pipes
67	           for _index_0 = 1, #_list_0 do
68	             local _continue_0 = false
69	             repeat
70	               local pipe = _list_0[_index_0]
debugger.lua> w1
62	           dbg()
63	=>         local res = setmetatable({
64	             headers = http_headers.new()
```

As you can see, the default line count is 5 on each side of the breakpoint.

You can customize the line count by adding a number after the command. The space between is optional.

It would be really cool to add syntax highlighting in the future.