### PR TITLE
avoid expanding tables in cmd_locals

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -306,7 +306,7 @@ local function cmd_locals()
 		
 		-- Skip the debugger object itself, temporaries and Lua 5.2's _ENV object.
 		if not rawequal(v, dbg) and k ~= "_ENV" and k ~= "(*temporary)" then
-			dbg.writeln("\t"..COLOR_BLUE.."%s "..COLOR_RED.."=>"..COLOR_RESET.." %s", k, pretty(v))
+			dbg.writeln("\t"..COLOR_BLUE.."%s "..COLOR_RED.."=>"..COLOR_RESET.." %s", k, pretty(v, true))
 		end
 	end
 	


### PR DESCRIPTION
I'm not a fan of the current behavior of the `locals` command, where tables are expanded automatically. This can get really messy when working with large tables.

The prime use case of the `locals` command is seeing which variables are in the current scope. With this commit, you can use the `print` command to inspect the contents of a table, but the `locals` command simply shows `table: 0x010df847c0`.