### PR TITLE
reset inspected frame on step/next/finish

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -212,6 +212,20 @@ end
 -- Wee version differences
 local unpack = unpack or table.unpack
 
+function cmd_step()
+	stack_offset = stack_top
+	return true, hook_step
+end
+
+function cmd_next()
+	stack_offset = stack_top
+	return true, hook_next
+end
+
+function cmd_finish()
+	return true, hook_finish
+end
+
 local function cmd_print(expr)
 	local env = local_bindings(1, true)
 	local chunk = compile_chunk("return ("..expr..")", env)
@@ -318,9 +332,9 @@ local last_cmd = false
 local function match_command(line)
 	local commands = {
 		["c"] = function() return true end,
-		["s"] = function() return true, hook_step end,
-		["n"] = function() return true, hook_next end,
-		["f"] = function() return true, hook_finish end,
+		["s"] = cmd_step,
+		["n"] = cmd_next,
+		["f"] = cmd_finish,
 		["p%s?(.*)"] = cmd_print,
 		["e%s?(.*)"] = cmd_eval,
 		["u"] = cmd_up,

--- a/debugger.lua
+++ b/debugger.lua
@@ -62,10 +62,10 @@ local help_message = [[
 c(ontinue) - continue execution
 s(tep) - step forward by one line (into functions)
 n(ext) - step forward by one line (skipping over functions)
+f(inish) - step forward until exiting the inspected frame
+u(p) - inspect the next frame up the stack
+d(own) - inspect the next frame down the stack
 p(rint) [expression] - execute the expression and print the result
-f(inish) - step forward until exiting the current function
-u(p) - move up the stack by one frame
-d(own) - move down the stack by one frame
 t(race) - print the stack trace
 l(ocals) - print the function arguments, locals and upvalues.
 h(elp) - print this message

--- a/debugger.lua
+++ b/debugger.lua
@@ -223,7 +223,9 @@ function cmd_next()
 end
 
 function cmd_finish()
-	return true, hook_finish
+	local offset = stack_top - stack_offset
+	stack_offset = stack_top
+	return true, offset < 0 and hook_factory(offset - 1) or hook_finish
 end
 
 local function cmd_print(expr)


### PR DESCRIPTION
- `step` and `next` now return to the bottom frame

Previously, if I used `up` and then `step` or `next`, the inspected frame would remain the same. With this commit, the inspected frame is reset to the bottom frame (aka the active frame).

- `finish` now works relative to the inspected frame

Previously, if I used `up` and then `finish`, the inspected frame would remain the same and only the bottom frame would be stepped out of. With this commit, the `finish` command will step up the stack until the inspected frame has been exited.