### PR TITLE
fix: print tuples

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -214,7 +214,7 @@ local unpack = unpack or table.unpack
 
 local function cmd_print(expr)
 	local env = local_bindings(1, true)
-	local chunk = compile_chunk("return ("..expr..")", env)
+	local chunk = compile_chunk("return "..expr, env)
 	if chunk == nil then return false end
 	
 	-- Call the chunk and collect the results.


### PR DESCRIPTION
I'm not sure if those parentheses were there for a reason, but removing them allows tuples to be printed!