### PR TITLE
feat: make dbg.call pass varargs to the guarded function

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -420,14 +420,21 @@ function dbg.assert(condition, message)
 end
 
 -- Works like pcall(), but invokes the debugger on an error.
-function dbg.call(f, l)
-	return (xpcall(f, function(err)
+function dbg.call(f, ...)
+	local catch = function(err)
 		dbg.writeln(COLOR_RED.."Debugger stopped on error: "..COLOR_RESET..pretty(err))
-		dbg(false, (l or 0) + 1)
-		
+		dbg(false, 2)
+
 		-- Prevent a tail call to dbg().
 		return
-	end))
+	end
+	if select('#', ...) > 0 then
+		local args = {...}
+		return xpcall(function()
+			return f(unpack(args))
+		end, catch)
+	end
+	return xpcall(f, catch)
 end
 
 -- Error message handler that can be used with lua_pcall().


### PR DESCRIPTION
This commit makes `dbg.call` identical to `pcall`.

```lua
local ok, a, b, c = dbg.call(function(a, b, c)
  return a + 1, b + 1, c + 1
end, 1, 2, 3)

print(a, b, c) --  2    3    4
```

#20 should be merged first