### PR TITLE
fix: print the inspected frame when repl() is called

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -366,8 +366,8 @@ local function run_command(line)
 end
 
 repl = function()
-	dbg.writeln(format_stack_frame_info(debug.getinfo(LOCAL_STACK_LEVEL - 3 + stack_top)))
-	
+	dbg.writeln(format_stack_frame_info(debug.getinfo(LOCAL_STACK_LEVEL - 3 + stack_offset)))
+
 	repeat
 		local success, done, hook = pcall(run_command, dbg.read(COLOR_RED.."debugger.lua> "..COLOR_RESET))
 		if success then


### PR DESCRIPTION
Previously, the bottom frame was printed.