### PR TITLE
fix: assume what="main" frames have a file

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -139,7 +139,7 @@ local repl
 -- Return false for stack frames without a source file,
 -- which includes C frames and pre-compiled Lua bytecode.
 local function frame_has_file(info)
-	return info.source:match('^@[%.%/]') ~= nil
+	return info.what == "main" or info.source:match("^@[%.%/]") ~= nil
 end
 
 local function hook_factory(repl_threshold)


### PR DESCRIPTION
The `what` property equals "main" when using `dbg()` within `foo.lua` where `lua foo.lua` was used, for example.