### PR TITLE
add hint how to run the debugger_lua.c.lua file

### DIFF
--- a/embed/debugger_lua.c.lua
+++ b/embed/debugger_lua.c.lua
@@ -1,3 +1,5 @@
+# run this file from the main folder, NOT from within the "embed" 
+
 local lua_src = string.format("%q", io.open("debugger.lua"):read("a"))
 
 -- Fix the weird escape characters


### PR DESCRIPTION
trying to run the debugger_lua.c.lua file from within the embed folder will result in "attempt to index a nil value" errors, which are not obvious, as to why they happen.
by reading through the readme, I've then found out that this file needs to be run from the main folder, which will allow "io.open('debugger.lua')" to not return nil. 

I've added a comment at the top of the file to make that obvious.