### PR TITLE
isatty fix for luvit runtime

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -586,7 +586,7 @@ if ffi then
 		return success and func or nil
 	end
 	
-	local isatty = get_func_or_nil("isatty") or get_func_or_nil("_isatty")
+	local isatty = get_func_or_nil("isatty") or get_func_or_nil("_isatty") or (ffi.load("ucrtbase"))["_isatty"]
 	stdin_isatty = isatty(0)
 	stdout_isatty = isatty(1)
 end


### PR DESCRIPTION
This makes the library usable with [luvit](https://github.com/luvit/luvit) runtime, however the tests wont run correctly because of the change in behaviour of 'require' (and it's output).

The library does work as expected as far as I've tested it even tho the tests mostly fail.

eg:
`expected: test.lua:12 in upvalue 'func2'
got     : E:\Projects\Lua\debugger.lua\test\test.lua:12 in upvalue 'func2'
`
Path is the full path of tests file, while luajit for example emits only the filename.

Sidenote: This seems to have been fixed before but changes reverted at some point, #12 refers to a similar issue aswell.