### PR TITLE
fix trying to concat nil value on dbg.assert

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -536,7 +536,7 @@ end
 -- Works like assert(), but invokes the debugger on a failure.
 function dbg.assert(condition, message)
 	if not condition then
-		dbg_writeln(COLOR_RED.."ERROR:"..COLOR_RESET..message)
+		dbg_writeln(COLOR_RED.."ERROR: "..COLOR_RESET..(message or "assertion failed!"))
 		dbg(false, 1, "dbg.assert()")
 	end
 	


### PR DESCRIPTION
message is optional and should default to "assertion failed!"