### PR TITLE
Add last line of string source for where command

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -216,6 +216,7 @@ local function where(info, context_lines)
 			pcall(function() for line in io.lines(filename) do table.insert(source, line) end end)
 		elseif info.source then
 			for line in info.source:gmatch("(.-)\n") do table.insert(source, line) end
+			table.insert(source, info.source:match("([^\n]*)$"))
 		end
 		SOURCE_CACHE[info.source] = source
 	end


### PR DESCRIPTION
When debugger.lua is operating on Lua code in a string, not in a file, the current method in `where()` using `string.gmatch` to split the string into lines leaves out the last line if it's not terminated with a newline. Added a line of code to include the final line.