### PR TITLE
fix `where` source line parser when loaded from `luaL_loadstring`

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -211,7 +211,7 @@ local function where(info, context_lines)
 	local source = SOURCE_CACHE[info.source]
 	if not source then
 		source = {}
-		local filename = info.source:match("@(.*)")
+		local filename = info.source:match("^@(.*)")
 		if filename then
 			pcall(function() for line in io.lines(filename) do table.insert(source, line) end end)
 		elseif info.source then

--- a/debugger.lua
+++ b/debugger.lua
@@ -80,7 +80,7 @@ end
 
 local function format_loc(file, line) return COLOR_BLUE..file..COLOR_RESET..":"..COLOR_YELLOW..line..COLOR_RESET end
 local function format_stack_frame_info(info)
-	local filename = info.source:match("@(.*)")
+	local filename = info.source:match("^@(.*)")
 	local source = filename and dbg.shorten_path(filename) or info.short_src
 	local namewhat = (info.namewhat == "" and "chunk at" or info.namewhat)
 	local name = (info.name and "'"..COLOR_BLUE..info.name..COLOR_RESET.."'" or format_loc(source, info.linedefined))

--- a/debugger.lua
+++ b/debugger.lua
@@ -215,7 +215,7 @@ local function where(info, context_lines)
 		if filename then
 			pcall(function() for line in io.lines(filename) do table.insert(source, line) end end)
 		elseif info.source then
-			for line in info.source:gmatch("[^\n]+") do table.insert(source, line) end
+			for line in info.source:gmatch("([^\n]*)\n?") do table.insert(source, line) end
 		end
 		SOURCE_CACHE[info.source] = source
 	end


### PR DESCRIPTION
assume source input string, and load from C by `luaL_loadstring`:

```
---@type number
local a = 1

dbg()  -- break here and use `where`
a = a + 1
```

there are two problems:
1. the `info.currentline` would be `5`, while the `source`'s empty lines would be ignored, result to length `4`
2. the `---@type` 's `@` would be used as filename pattern, which was not right

both of these problems would results to `Error: Source not available for xxx`