### PR TITLE
Forward all args from dbg.assert to lua_assert

### DIFF
--- a/debugger.lua
+++ b/debugger.lua
@@ -524,14 +524,13 @@ function dbg.error(err, level)
 end
 
 -- Works like assert(), but invokes the debugger on a failure.
-function dbg.assert(condition, message)
-	message = message or "assertion failed!"
+function dbg.assert(condition, message, ...)
 	if not condition then
-		dbg_writeln(COLOR_RED.."ERROR: "..COLOR_RESET..message)
+		dbg_writeln(COLOR_RED.."ERROR: "..COLOR_RESET..(message or "assertion failed!"))
 		dbg(false, 1, "dbg.assert()")
 	end
 	
-	return lua_assert(condition, message)
+	return lua_assert(condition, message, ...)
 end
 
 -- Works like pcall(), but invokes the debugger on an error.


### PR DESCRIPTION
Lua's assert returns all provided arguments if there is no error - this change tries to match Lua's behavior.

Before this change, `local a, b, c = dbg.assert('a', 'b', 'c')` would make the values `a, b, c == 'a', 'assertion failed!', nil`.